### PR TITLE
feat: add card authorization listener port

### DIFF
--- a/src/main/java/io/openfednow/shadowledger/CardAuthorizationEventListener.java
+++ b/src/main/java/io/openfednow/shadowledger/CardAuthorizationEventListener.java
@@ -1,0 +1,33 @@
+package io.openfednow.shadowledger;
+
+/**
+ * Port for real-time card authorization events from an institution's card
+ * processor.
+ *
+ * <p>Implementations should call {@link ShadowLedger#applyDebit(String, long,
+ * String)} for authorizations and the matching credit path for reversals so
+ * the Shadow Ledger stays synchronized with STIP-approved card activity while
+ * the core is unavailable. Vendor-specific processors such as Visa DPS, FIS
+ * CardManager, Fiserv STAR, or Jack Henry should be integrated in separate
+ * adapter modules.
+ */
+public interface CardAuthorizationEventListener {
+
+    /**
+     * Handles an approved card authorization that should reduce available balance.
+     *
+     * @param accountId the account that received the authorization
+     * @param amountCents the authorized amount in cents
+     * @param authCode the card processor authorization code
+     */
+    void onAuthorization(String accountId, long amountCents, String authCode);
+
+    /**
+     * Handles a card authorization reversal that should restore available balance.
+     *
+     * @param accountId the account that received the reversal
+     * @param amountCents the reversed amount in cents
+     * @param originalAuthCode the original card processor authorization code
+     */
+    void onReversal(String accountId, long amountCents, String originalAuthCode);
+}

--- a/src/main/java/io/openfednow/shadowledger/NoOpCardAuthorizationEventListener.java
+++ b/src/main/java/io/openfednow/shadowledger/NoOpCardAuthorizationEventListener.java
@@ -1,0 +1,26 @@
+package io.openfednow.shadowledger;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default no-op {@link CardAuthorizationEventListener}.
+ *
+ * <p>This keeps card authorization event handling opt-in. Institutions can set
+ * {@code openfednow.card-authorization.enabled=true} and provide their own
+ * listener backed by a card processor event stream.
+ */
+@Component
+@ConditionalOnProperty(name = "openfednow.card-authorization.enabled", havingValue = "false", matchIfMissing = true)
+public class NoOpCardAuthorizationEventListener implements CardAuthorizationEventListener {
+
+    @Override
+    public void onAuthorization(String accountId, long amountCents, String authCode) {
+        // Intentionally empty: card authorization integration is institution-specific.
+    }
+
+    @Override
+    public void onReversal(String accountId, long amountCents, String originalAuthCode) {
+        // Intentionally empty: card authorization integration is institution-specific.
+    }
+}

--- a/src/test/java/io/openfednow/shadowledger/NoOpCardAuthorizationEventListenerTest.java
+++ b/src/test/java/io/openfednow/shadowledger/NoOpCardAuthorizationEventListenerTest.java
@@ -1,0 +1,19 @@
+package io.openfednow.shadowledger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class NoOpCardAuthorizationEventListenerTest {
+
+    @Autowired
+    private CardAuthorizationEventListener listener;
+
+    @Test
+    void noOpListenerIsAutoWiredByDefault() {
+        assertThat(listener).isInstanceOf(NoOpCardAuthorizationEventListener.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add the `CardAuthorizationEventListener` shadow-ledger port
- provide an opt-in no-op default listener matching the existing conditional bean pattern
- add Spring Boot coverage that verifies the default listener is wired

## Tests
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk mvn test -Dtest=NoOpCardAuthorizationEventListenerTest`

Closes #69